### PR TITLE
DockerをM1macに対応したものに変更する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ COPY . $APP_ROOT
 RUN <<EOF
   gem install bundler
   gem install rails -v $RAILS_VERSION
+  apk add --no-cache libc6-compat gcompat
   bundle install
 EOF
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,12 @@ RUN mkdir -p $APP_ROOT
 WORKDIR $APP_ROOT
 COPY . $APP_ROOT
 
+# M1 Mac用
+RUN if [ "$(uname -m)" = "aarch64" ]; then apk add --no-cache libc6-compat gcompat; fi
+
 RUN <<EOF
   gem install bundler
   gem install rails -v $RAILS_VERSION
-  apk add --no-cache libc6-compat gcompat
   bundle install
 EOF
 


### PR DESCRIPTION
## 該当チケット
#34 

## やったこと
M1 macが動作するようDockerfileを変更

## 動作確認
- M1macで起動することを確認
  - "aarch64"を"x86_64"にすると起動できないことを確認

## 参考にした記事
https://engineer.blog.lancers.jp/mysql/docker-m1-mac/#:~:text=M1%20Mac%E3%81%AE%E5%A0%B4%E5%90%88%E3%81%AFarm64%E7%89%88%E3%82%92%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB%E3%81%99%E3%82%8B%E3%81%9F%E3%82%81%E3%81%AB%E3%80%81%E4%BB%A5%E4%B8%8B%E3%81%AE%E3%82%88%E3%81%86%E3%81%AB%E3%81%97%E3%81%BE%E3%81%97%E3%81%9F%E3%80%82

[DockerFileにif文(条件分岐)](https://qiita.com/t_n/items/203cd3593427a35f7ed7)